### PR TITLE
legg til mulighet til å filtrere bort meldinger bruker ikke bryr seg om

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,15 @@ source:
   flag-field-config:
     - key1
     - key2/key3
+  # OBS: Behold KUN de meldingene som matcher regelene nedenfor. Liste med key/value-pairs
+  # Alle meldinger som ikke matcher vil bli satt til NONE
+  message-filter:
+  - key: <feltnavn-kafka-message>
+    allowed_value: <verdinavn du vil beholde>
+  - key: <nytt eller samme feltnavn-kafka-message>
+    allowed_value: <verdinavn du vil beholde>
+    ...
+    
 # Mål
 target:
   # Kun Oracle er støttet for øyeblikket

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ source:
     - key2/key3
   # OBS: Behold KUN de meldingene som matcher regelene nedenfor. Liste med key/value-pairs
   # Alle meldinger som ikke matcher vil bli satt til NONE
-  message-filter:
+  message-filters:
   - key: <feltnavn-kafka-message>
     allowed_value: <verdinavn du vil beholde>
   - key: <nytt eller samme feltnavn-kafka-message>

--- a/src/config.py
+++ b/src/config.py
@@ -65,6 +65,11 @@ class KafkaConsumerStrategy(StrEnum):
     SUBSCRIBE = "subscribe"
 
 
+class MessageFilter(BaseModel):
+    key: str
+    allowed_value: str
+
+
 class SourceConfig(BaseModel):
     model_config = ConfigDict(use_enum_values=True)
 
@@ -78,6 +83,7 @@ class SourceConfig(BaseModel):
     keypath_separator: Optional[str] = Field(None, alias="keypath-seperator")
     message_fields_filter: Optional[list] = Field(None, alias="message-fields-filter")
     flag_field_config: Optional[list] = Field(None, alias="flag-field-config")
+    message_filters: Optional[list[MessageFilter]] = Field(None, alias="message-filter")
     poll_timeout: int = Field(
         10,
         alias="poll-timeout",

--- a/src/config.py
+++ b/src/config.py
@@ -83,7 +83,7 @@ class SourceConfig(BaseModel):
     keypath_separator: Optional[str] = Field(None, alias="keypath-seperator")
     message_fields_filter: Optional[list] = Field(None, alias="message-fields-filter")
     flag_field_config: Optional[list] = Field(None, alias="flag-field-config")
-    message_filters: Optional[list[MessageFilter]] = Field(None, alias="message-filter")
+    message_filters: Optional[list[MessageFilter]] = Field(None, alias="message-filters")
     poll_timeout: int = Field(
         10,
         alias="poll-timeout",

--- a/src/development/test_kafka_source.py
+++ b/src/development/test_kafka_source.py
@@ -35,7 +35,7 @@ def config1(base_config):
     config["source"]["topic"] = TOPIC_NAME
     config["source"]["strategy"] = "subscribe"
     config["source"]["group-id"] = "test_kafka_source"
-    config["source"]["message-filter"] = [{"key": "enum", "allowed_value": "INTERESTING"}]
+    config["source"]["message-filters"] = [{"key": "enum", "allowed_value": "INTERESTING"}]
     return config
 
 

--- a/src/development/test_kafka_source.py
+++ b/src/development/test_kafka_source.py
@@ -1,55 +1,86 @@
 import pytest
-import os
 import json
-import uuid
 
 from confluent_kafka import Consumer
 from confluent_kafka.admin import NewTopic
 
-topic = "kafka_source"
+from ..kafka_source import KafkaSource
 
-
-@pytest.fixture
-def consumer_2(broker):
-    return Consumer(
-        {
-            "bootstrap.servers": broker,
-            "group.id": "testersen-id",
-            "auto.offset.reset": "earliest",
-            "enable.auto.commit": False,
-            "max.poll.interval.ms": 12000,
-            "session.timeout.ms": 10000,
-            "enable.partition.eof": True,
-        }
-    )
+TOPIC_NAME = "test-topic-kafka-source"
 
 
 @pytest.fixture(autouse=True)
-def setup_kafka_topic(kafka_admin_client, producer):
-
-    kafka_admin_client.create_topics([NewTopic(topic, 2)])
+def setUpKafka(producer, kafka_admin_client):
+    kafka_admin_client.create_topics([NewTopic(TOPIC_NAME, 2)])
     for i in range(4):
         producer.produce(
-            topic,
+            TOPIC_NAME,
             key=f"key{i}",
-            value=json.dumps({"id": i, "value": f"Message {i}"}),
+            value=json.dumps({"id": i, "value": f"Message {i}", "enum": "INTERESTING"}),
+            partition=i % 2,
+        )
+    for i in range(4, 8):
+        producer.produce(
+            TOPIC_NAME,
+            key=f"key{i}",
+            value=json.dumps({"id": i, "value": f"Message {i}", "enum": "NOT_RELEVANT"}),
             partition=i % 2,
         )
     producer.flush()
 
 
-def test_2_partitions(consumer_2):
-    consumer_2.subscribe([topic])
-    m = consumer_2.consume(6, 5)
-    consumer_2.commit()
-    consumer_2.close()
+@pytest.fixture
+def config1(base_config):
+    config = base_config
+    config["source"]["topic"] = TOPIC_NAME
+    config["source"]["strategy"] = "subscribe"
+    config["source"]["group-id"] = "test_kafka_source"
+    config["source"]["message-filter"] = [{"key": "enum", "allowed_value": "INTERESTING"}]
+    return config
 
 
-def test_2_partitions2(consumer_2):
-    consumer_2.subscribe([topic])
-    ms = []
-    for i in range(4):
-        ms.append(consumer_2.poll())
-    assert len(consumer_2.list_topics().topics[topic].partitions.keys()) == 2
-    consumer_2.commit()
-    consumer_2.close()
+def test_collect_message(consumer, config1):
+    consumer.subscribe([TOPIC_NAME])
+    messages = [consumer.poll() for _ in range(8)]
+    # consumer.commit()
+    consumer.close()
+
+    source = KafkaSource(config1["source"])
+
+    filtered_messages = [source.collect_message(m) for m in messages]
+    assert filtered_messages[0]["kafka_message"] is not None
+    assert filtered_messages[1]["kafka_message"] is not None
+    assert filtered_messages[4]["kafka_message"] is not None
+    assert filtered_messages[5]["kafka_message"] is not None
+    assert filtered_messages[2]["kafka_message"] == None
+    assert filtered_messages[3]["kafka_message"] == None
+    assert filtered_messages[6]["kafka_message"] == None
+    assert filtered_messages[7]["kafka_message"] == None
+
+
+@pytest.fixture
+def config_no_message_filter(base_config):
+    config = base_config
+    config["source"]["topic"] = TOPIC_NAME
+    config["source"]["strategy"] = "subscribe"
+    config["source"]["group-id"] = "test_kafka_source"
+    return config
+
+
+def test_collect_message(consumer, config_no_message_filter):
+    consumer.subscribe([TOPIC_NAME])
+    messages = [consumer.poll() for _ in range(8)]
+    # consumer.commit()
+    consumer.close()
+
+    source = KafkaSource(config_no_message_filter["source"])
+
+    filtered_messages = [source.collect_message(m) for m in messages]
+    assert filtered_messages[0]["kafka_message"] is not None
+    assert filtered_messages[1]["kafka_message"] is not None
+    assert filtered_messages[4]["kafka_message"] is not None
+    assert filtered_messages[5]["kafka_message"] is not None
+    assert filtered_messages[2]["kafka_message"] is not None
+    assert filtered_messages[3]["kafka_message"] is not None
+    assert filtered_messages[6]["kafka_message"] is not None
+    assert filtered_messages[7]["kafka_message"] is not None

--- a/src/kafka_source.py
+++ b/src/kafka_source.py
@@ -188,6 +188,17 @@ class KafkaSource(Source):
         message["kafka_topic"] = msg.topic()
         message.update(self.value_deserializer(msg.value()))
 
+        # Ignore certain messages
+        message_filters = self.config.message_filters
+        if message_filters:
+            valid_message = False
+            for filter in message_filters:
+                # Keep only these messages
+                if filter.key in message and filter.allowed_value == message[filter.key]:
+                    valid_message = True
+                    break
+            if not valid_message:
+                message["kafka_message"] = None
         return message
 
     def _prepare_partitions(


### PR DESCRIPTION
Her er førsteutkast til funksjonalitet som @elisnes har forespurt

Ny feature, message-filter:
Ved å velg legge til følgende i config:
```yaml
  message-filter:
  - key: type
    allowed_value: NL_OPPFOLGINGSPLAN_FORESPORSEL
```

så vil ALLE `kafka_message` der type!=NL_OPPFOLGINGSPLAN_FORESPORSEL bli satt til None.

Jeg har valgt å legge filteret i metoden `collect_message` for å ikke trenge å legge logikken flere steder.
Jeg har skrevet noen tester for å validere at meldinger ikke blir satt til None når filteret er tomt eller ikke i bruk.

Tar gjerne imot tilbakemeldigner / forbedringsforslag