### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,9 @@ name: Python CI
 
 on: [push, workflow_dispatch]
 
+permissions:
+  contents: read
+
 env:
   PYTHON_VERSION: 3.12
   POETRY_VERSION: 2.1.1


### PR DESCRIPTION
Potential fix for [https://github.com/navikt/dvh-airflow-kafka/security/code-scanning/1](https://github.com/navikt/dvh-airflow-kafka/security/code-scanning/1)

To fix the issue, we will add a `permissions` block to the workflow file. Since the workflow does not appear to require write access to any repository resources, we will set the permissions to `contents: read`, which is the minimal permission required for workflows that interact with repository contents. This change will be applied at the root level of the workflow to cover all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
